### PR TITLE
Make the code compatible with Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ sudo: false  # use container-based infrastructure
 language: python
 python:
   - "2.7"
+  - "3.4"
+  - "3.5"
 install: "pip install -r requirements.txt"
 script: nosetests --with-coverage --cover-tests
 

--- a/RangeHTTPServer.py
+++ b/RangeHTTPServer.py
@@ -13,8 +13,16 @@ browser all at once.
 import os
 import re
 import sys
-from SimpleHTTPServer import SimpleHTTPRequestHandler
-import SimpleHTTPServer
+
+try:
+    # Python3
+    from http.server import SimpleHTTPRequestHandler
+    import http.server as SimpleHTTPServer
+
+except ImportError:
+    # Python 2
+    from SimpleHTTPServer import SimpleHTTPRequestHandler
+    import SimpleHTTPServer
 
 
 def copy_byte_range(infile, outfile, start=None, stop=None, bufsize=16*1024):

--- a/tests/RangeHTTPServer_test.py
+++ b/tests/RangeHTTPServer_test.py
@@ -4,7 +4,8 @@ sys.path = ['.'] + sys.path
 import RangeHTTPServer
 
 from nose.tools import *
-from StringIO import StringIO
+
+from io import StringIO
 
 
 def test_parse_byte_range():
@@ -22,7 +23,7 @@ def test_parse_byte_range():
 
 
 def test_copy_byte_range():
-    inbuffer = StringIO('0123456789abcdefghijklmnopqrstuvwxyz')
+    inbuffer = StringIO(u'0123456789abcdefghijklmnopqrstuvwxyz')
     outbuffer = StringIO()
 
     RangeHTTPServer.copy_byte_range(inbuffer, outbuffer, 4, 10)

--- a/tests/server_test.py
+++ b/tests/server_test.py
@@ -6,7 +6,14 @@ from RangeHTTPServer import RangeRequestHandler
 
 from nose.tools import *
 
-from BaseHTTPServer import HTTPServer
+try:
+    # Python 3
+    from http.server import HTTPServer
+
+except ImportError:
+    # Python2
+    from BaseHTTPServer import HTTPServer
+
 import requests
 import threading
 import time


### PR DESCRIPTION
Just a trivial pull request to have this module run with Python 3.

Note that the `io` module was introduced in Python 2.6, so if you want to remain compatible with older versions then this pull request needs a tiny little bit more work. :smiley: 
