### PR TITLE
Python3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: python
 python:
   - "2.7"
   - "3.4"
+  - "3.5"
 install: "pip install -r requirements.txt"
 script: nosetests --with-coverage --cover-tests
 

--- a/RangeHTTPServer.py
+++ b/RangeHTTPServer.py
@@ -115,13 +115,17 @@ class RangeRequestHandler(SimpleHTTPRequestHandler):
 
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser()
-    parser.add_argument('--bind', '-b', default='', metavar='ADDRESS',
-                        help='Specify alternate bind address '
-                             '[default: all interfaces]')
-    parser.add_argument('port', action='store',
-                        default=8000, type=int,
-                        nargs='?',
-                        help='Specify alternate port [default: 8000]')
-    args = parser.parse_args()
-    http_server.test(HandlerClass=RangeRequestHandler, port=args.port, bind=args.bind)
+    if sys.version_info[0] == 2:
+        http_server.test(HandlerClass=RangeRequestHandler)
+        # Python2's SimpleHTTPServer.test doesn't support bind and port args
+    else:
+        parser = argparse.ArgumentParser()
+        parser.add_argument('--bind', '-b', default='', metavar='ADDRESS',
+                            help='Specify alternate bind address '
+                                 '[default: all interfaces]')
+        parser.add_argument('port', action='store',
+                            default=8000, type=int,
+                            nargs='?',
+                            help='Specify alternate port [default: 8000]')
+        args = parser.parse_args()
+        http_server.test(HandlerClass=RangeRequestHandler, port=args.port, bind=args.bind)


### PR DESCRIPTION
test_copy_byte_range should work with arbitrary buffers, #12 forgot to take that into consideration (StringIO is for unicode-text ) (note that this is just how it was done originally in #10 )

aside from that and the **main**, it's completely the same...
