### PR TITLE
Fix tests

### DIFF
--- a/tests/server_test.py
+++ b/tests/server_test.py
@@ -1,6 +1,3 @@
-# Import RangeHTTPServer from this project, not the global install.
-import sys
-sys.path = ['.'] + sys.path
 from RangeHTTPServer import RangeRequestHandler
 
 import pytest

--- a/tests/server_test.py
+++ b/tests/server_test.py
@@ -2,13 +2,7 @@ from RangeHTTPServer import RangeRequestHandler
 
 import pytest
 
-try:
-    # Python 3
-    from http.server import HTTPServer
-
-except ImportError:
-    # Python2
-    from BaseHTTPServer import HTTPServer
+from http.server import HTTPServer
 
 import requests
 import threading

--- a/tests/server_test.py
+++ b/tests/server_test.py
@@ -1,12 +1,11 @@
-from RangeHTTPServer import RangeRequestHandler
-
-import pytest
-
 from http.server import HTTPServer
-
-import requests
 import threading
 import time
+
+import pytest
+import requests
+
+from RangeHTTPServer import RangeRequestHandler
 
 
 httpd = None


### PR DESCRIPTION
Hey :wave: Arch Linux maintainer here

This ensures the tests pass on Arch Linux, with the following Python and pytest versions:

```sh
$ python --version
Python 3.12
$ pytest --version
pytest 8.3.2
```

See commit messages for details.

Resolves #38 